### PR TITLE
Don't support partial pacman upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ rustup component add rustfmt
 # -- or --
 sudo apt install meld
 # -- or --
-pacman -Sy zsh
+pacman -S zsh
 # -- or --
 rua install peek
 # -- or --

--- a/src/catch.rs
+++ b/src/catch.rs
@@ -85,7 +85,7 @@ fn match_pacman(line: &str) -> Result<Vec<Package>, Box<dyn Error>> {
     match_multiple(
         line,
         PackageSource::Pacman,
-        r"pacman\s+-Sy?\s+(-\S+\s+)*(?P<name>[.\w\s-]+)",
+        r"pacman\s+-S?\s+(-\S+\s+)*(?P<name>[.\w\s-]+)",
         r"([[:word:]]\S*)",
     )
 }
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn test_pacman_matches() {
-        multiple_match(match_pacman, vec!["test", "test2"], "pacman -Sy test test2");
+        multiple_match(match_pacman, vec!["test", "test2"], "pacman -S test test2");
 
         no_match(match_pacman, "sudo snap install tor-middle-relay");
     }

--- a/src/package.rs
+++ b/src/package.rs
@@ -106,7 +106,7 @@ impl PackageSource {
             PackageSource::Cargo => vec!["cargo", "install", "--quiet"],
             PackageSource::RustupComponent => vec!["rustup", "component", "add"],
             PackageSource::Apt => vec!["apt", "install"],
-            PackageSource::Pacman => vec!["pacman", "-Sy", "--noconfirm", "--quiet"],
+            PackageSource::Pacman => vec!["pacman", "-S", "--noconfirm", "--quiet"],
             PackageSource::Rua => vec!["rua", "install"],
             PackageSource::Snap => vec!["snap", "install"],
             PackageSource::Pip => vec!["pip", "install", "-q"],


### PR DESCRIPTION
[According to the Arch Wiki](https://wiki.archlinux.org/index.php/System_maintenance#Partial_upgrades_are_unsupported), partial upgrades via `pacman -Sy [package]` are not supported because of potential system-wide dependency breakage. This PR prevents such upgrades.