### PR TITLE
Add support for Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ pip3 install --user termtosvg
 choco install neovim
 # -- or --
 scoop install curl
+# -- or --
+nix-env -iA nixpkgs.nixfmt
 ```
 
 ### Synchronizing On Another Machine

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
     | OS | Package Manager |
     | :---: | --- |
     | <img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/debian.svg" width="18" height="18" /><img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/ubuntu.svg" width="18" height="18" /> | Apt |
+    | <img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/nixos.svg" width="18" height="18" /> | Nix |
     | <img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/archlinux.svg" width="18" height="18" /> | Pacman |
     | <img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/archlinux.svg" width="18" height="18" /> | RUA |
     | <img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/archlinux.svg" width="18" height="18" /> | Yay |

--- a/src/package.rs
+++ b/src/package.rs
@@ -41,6 +41,8 @@ pub enum PackageSource {
     Npm,
     ///AUR Helper written in go
     Yay,
+    /// NixOS Nix
+    Nix,
 }
 
 impl PackageSource {
@@ -60,6 +62,7 @@ impl PackageSource {
             PackageSource::Pip3User => "Python Pip 3 --user",
             PackageSource::Npm => "Node Package Manager",
             PackageSource::Yay => "AUR Helper written in go",
+            PackageSource::Nix => "Nix",
         }
     }
 
@@ -85,6 +88,7 @@ impl PackageSource {
             PackageSource::Pip3User => "pip3",
             PackageSource::Npm => "npm",
             PackageSource::Yay => "yay",
+            PackageSource::Nix => "nix-env",
             _ => "",
         }
     }
@@ -119,6 +123,7 @@ impl PackageSource {
             PackageSource::Pip3 => vec!["pip3", "install", "-q"],
             PackageSource::Pip3User => vec!["pip3", "install", "-q", "--user"],
             PackageSource::Npm => vec!["npm", "install", "-g"],
+            PackageSource::Nix => vec!["nix-env", "-iA", "-g"],
             _ => vec![],
         }
     }
@@ -153,6 +158,7 @@ impl PackageSource {
             PackageSource::Pip3 => Some("pip3 show -q"),
             PackageSource::Pip3User => Some("pip3 show -q"),
             PackageSource::Npm => Some("npm list --depth=0 -g | grep -q"),
+            PackageSource::Nix => Some("nix-env -q | grep -q"),
             _ => None,
         }
     }
@@ -188,6 +194,7 @@ impl PackageSource {
             PackageSource::Pip3User => false,
             PackageSource::Npm => false,
             PackageSource::Yay => false,
+            PackageSource::Nix => false,
         }
     }
 }


### PR DESCRIPTION
[Nix](https://nixos.org/nix/) is a purely functional package manager for Linux and other Unix systems that makes package management reliable and reproducible. It provides atomic upgrades and rollbacks, side-by-side installation of multiple versions of a package, multi-user package management and easy setup of build environments.
    
This commit adds initial support for `nix-env`, command used to install Nix packages in user environment.