### PR TITLE
Fixed issue #71, added config subcommand and function to set a git remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ It will parse your history and prompt to select, which packages you want to sync
 
 Run `emplace clean` and select the packages you want to be cleaned, they won't be removed from your system.
 
+
+### Creating and modifying config files
+Run `emplace config --new` to create a new config and configure the repository or `emplace config --path` to retrieve the path to the configuration file
 ## Contributors
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,12 +93,20 @@ impl Config {
             None => Config::new(),
         }
     }
+    /// Ask the user if he wants to change the repo path, clone it or create locally, or abort
     pub fn clone_repo_ask(&mut self) -> Result<bool> {
         let prompt = String::from("Choose what to do with the repository");
-        let choices = &["Change repository path before cloning it","Clone the repo or create the repository locally", "Do nothing for now"];
-        let chosen = dialoguer::MultiSelect::new().with_prompt(prompt).items(choices).interact()?;
+        let choices = &[
+            "Change repository path before cloning it",
+            "Clone the repo or create the repository locally",
+            "Do nothing for now",
+        ];
+        let chosen = dialoguer::MultiSelect::new()
+            .with_prompt(prompt)
+            .items(choices)
+            .interact()?;
         if chosen.contains(&2) {
-            return Ok(false)
+            return Ok(false);
         }
         if chosen.contains(&0) {
             let repo_path = dialoguer::Input::<String>::new()
@@ -108,20 +116,23 @@ impl Config {
             self.save_to_default_path()?;
         }
         if chosen.contains(&1) {
-            let choices_in = &["Clone the repo","Create it locally"];
+            let choices_in = &["Clone the repo", "Create it locally"];
             let chosen_in = dialoguer::Select::new().items(choices_in).interact()?;
             if chosen_in == 0 {
-                return super::git::clone_single_branch(&self.repo_directory,&self.repo.url,&self.repo.branch)
-            }
-            else {
-                fs::DirBuilder::new().recursive(true).create(&self.repo_directory)?;
-                return super::git::set_remote(&self.repo_directory, &self.repo.url)
+                return super::git::clone_single_branch(
+                    &self.repo_directory,
+                    &self.repo.url,
+                    &self.repo.branch,
+                );
+            } else {
+                fs::DirBuilder::new()
+                    .recursive(true)
+                    .create(&self.repo_directory)?;
+                return super::git::set_remote(&self.repo_directory, &self.repo.url);
             }
         }
         Ok(true)
-
     }
-
 
     /// Try to open the default.
     pub fn from_default_file() -> Result<Option<Self>> {
@@ -179,6 +190,7 @@ impl Config {
         base
     }
 
+    // Modified it to pub to be able to retrieve the config path from main
     pub fn default_path() -> PathBuf {
         dirs::config_dir()
             .expect("Could not find config dir")

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,6 +93,35 @@ impl Config {
             None => Config::new(),
         }
     }
+    pub fn clone_repo_ask(&mut self) -> Result<bool> {
+        let prompt = String::from("Choose what to do with the repository");
+        let choices = &["Change repository path before cloning it","Clone the repo or create the repository locally", "Do nothing for now"];
+        let chosen = dialoguer::MultiSelect::new().with_prompt(prompt).items(choices).interact()?;
+        if chosen.contains(&2) {
+            return Ok(false)
+        }
+        if chosen.contains(&0) {
+            let repo_path = dialoguer::Input::<String>::new()
+                .with_prompt("Where do you want your repository to be located")
+                .interact()?;
+            self.repo_directory = repo_path;
+            self.save_to_default_path()?;
+        }
+        if chosen.contains(&1) {
+            let choices_in = &["Clone the repo","Create it locally"];
+            let chosen_in = dialoguer::Select::new().items(choices_in).interact()?;
+            if chosen_in == 0 {
+                return super::git::clone_single_branch(&self.repo_directory,&self.repo.url,&self.repo.branch)
+            }
+            else {
+                fs::DirBuilder::new().recursive(true).create(&self.repo_directory)?;
+                return super::git::set_remote(&self.repo_directory, &self.repo.url)
+            }
+        }
+        Ok(true)
+
+    }
+
 
     /// Try to open the default.
     pub fn from_default_file() -> Result<Option<Self>> {
@@ -117,10 +146,15 @@ impl Config {
 
     /// Persist the config on disk.
     pub fn save_to_default_path(&self) -> Result<()> {
+        // Workaround to Issue #71
+        // As suggested in issue #142 on toml-rs github repository
+        // First convert the Config instance to a toml Value,
+        // then serialize it to toml
+        let value = toml::Value::try_from(self)?;
         fs::write(
             Config::default_path(),
             // Hardcode the default TOML config
-            toml::to_string(self)?,
+            toml::to_string(&value)?,
         )?;
 
         info!(
@@ -145,7 +179,7 @@ impl Config {
         base
     }
 
-    fn default_path() -> PathBuf {
+    pub fn default_path() -> PathBuf {
         dirs::config_dir()
             .expect("Could not find config dir")
             .join("emplace.toml")

--- a/src/git.rs
+++ b/src/git.rs
@@ -116,7 +116,8 @@ pub fn clone_single_branch<P: AsRef<Path>>(dir: &P, url: &str, branch: &str) -> 
 }
 /// Set remote origin
 pub fn set_remote<P: AsRef<Path>>(dir: &P, remote: &str) -> Result<bool> {
-    call_on_path(vec!["git", "remote", "add", "origin", remote], dir).context("failed setting remote origin")
+    call_on_path(vec!["git", "remote", "add", "origin", remote], dir)
+        .context("failed setting remote origin")
 }
 
 /// Stage a specific file for commiting.

--- a/src/git.rs
+++ b/src/git.rs
@@ -114,6 +114,10 @@ pub fn clone_single_branch<P: AsRef<Path>>(dir: &P, url: &str, branch: &str) -> 
 
     Ok(success)
 }
+/// Set remote origin
+pub fn set_remote<P: AsRef<Path>>(dir: &P, remote: &str) -> Result<bool> {
+    call_on_path(vec!["git", "remote", "add", "origin", remote], dir).context("failed setting remote origin")
+}
 
 /// Stage a specific file for commiting.
 pub fn add_file<P: AsRef<Path>>(dir: &P, file: &str) -> Result<bool> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,26 @@ fn safe_main() -> Result<()> {
 						.takes_value(true)
 				),
 		)
+                .subcommand(
+                    SubCommand::with_name("config")
+                    .about("Provides options for managing configuration")
+                    .arg(
+                        Arg::with_name("new")
+                        .short("n")
+                        .long("new")
+                        .help("Create a new config")
+                        .required_unless("path")
+                        .takes_value(false)
+                    )
+                    .arg(
+                        Arg::with_name("path")
+                        .short("p")
+                        .long("path")
+                        .help("Print out path to config")
+                        .required_unless("new")
+                        .takes_value(false)
+                    ),
+                )
 		.get_matches();
 
     match matches.subcommand() {
@@ -94,6 +114,22 @@ fn safe_main() -> Result<()> {
             );
 
             history::history(&hist_path).context("capturing history")
+        }
+        // Config subcommand, if path is present and new is not
+        // it will just print the default path for the config file
+        // else it will create a new config and ask what to do about the repository
+        ("config", Some(subm)) => {
+            if subm.is_present("path") && !subm.is_present("new") {
+                println!(
+                    "Your config path is {}",
+                    config::Config::default_path().to_str().unwrap()
+                );
+                Ok(())
+            } else {
+                let mut config = config::Config::new()?;
+                config.clone_repo_ask()?;
+                Ok(())
+            }
         }
         (&_, _) => Ok(()),
     }


### PR DESCRIPTION
#71 Fixed by first converting the Config value into a toml Value then serializing it.
As suggested in [Issue #142 - toml-rs](https://github.com/alexcrichton/toml-rs/issues/142#issuecomment-278970591)
Unfortunately the solution presented later and merged into master doesn't apply to this so the first workaround had to be used.
Also added a way to create a new config and configure the repo including changing the path from the default using dialoguer MultiSelect and Select prompts and by adding a new subcommand with two command line switches. To allow setting a new repo path and creating one locally I also had to add a function to set a git remote for the repository.
Code has been formatted with RustFmt and checked with clippy.
If there's anything that needs to be fixed or changed for this to work then please let me know.