### PR TITLE
add zypper support

### DIFF
--- a/src/package_manager/mod.rs
+++ b/src/package_manager/mod.rs
@@ -16,6 +16,7 @@ mod rustup;
 mod scoop;
 mod snap;
 mod yay;
+mod zypper;
 
 pub use apt::Apt;
 pub use brew::Brew;
@@ -32,6 +33,7 @@ pub use rustup::Rustup;
 pub use scoop::Scoop;
 pub use snap::Snap;
 pub use yay::Yay;
+pub use zypper::Zypper;
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -58,6 +60,7 @@ pub enum PackageManager {
     Scoop,
     Snap,
     Yay,
+    Zypper,
 }
 
 /// Trait that needs to be implemented for a new package manager.

--- a/src/package_manager/zypper.rs
+++ b/src/package_manager/zypper.rs
@@ -1,0 +1,73 @@
+use super::{CaptureFlag, PackageInstalledMethod, PackageManagerTrait};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Zypper;
+
+impl PackageManagerTrait for Zypper {
+    fn full_name(self) -> &'static str {
+        "Zypper"
+    }
+
+    fn commands(self) -> Vec<&'static str> {
+        vec!["zypper"]
+    }
+
+    fn sub_commands(self) -> Vec<&'static str> {
+        vec!["in", "install"]
+    }
+
+    fn install_command(self) -> &'static str {
+        "zypper install -y"
+    }
+
+    fn needs_root(self) -> bool {
+        true
+    }
+
+    fn is_installed(self, package: &str) -> PackageInstalledMethod {
+        PackageInstalledMethod::Script(format!("rpm -q {}", package))
+    }
+
+    fn known_flags_with_values(self) -> Vec<&'static str> {
+        // TODO
+        vec![]
+    }
+
+    fn capture_flags(self) -> Vec<CaptureFlag> {
+        // TODO
+        vec![]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Zypper;
+    use crate::{catch, package_manager::PackageManager};
+
+    #[test]
+    fn test_package_manager() {
+        let manager = PackageManager::from_line("zypper install test").unwrap();
+        assert_eq!(manager, PackageManager::from(Zypper));
+    }
+
+    #[test]
+    fn test_catch() {
+        // Regular invocation
+        catch!(PackageManager::from(Zypper), "sudo zypper install test" => "test");
+        catch!(PackageManager::from(Zypper), "sudo zypper in test" => "test");
+        catch!(PackageManager::from(Zypper), "zypper install test" => "test");
+        catch!(PackageManager::from(Zypper), "zypper in test" => "test");
+        catch!(PackageManager::from(Zypper), "sudo zypper install lib32gfortran5-x32-cross" => "lib32gfortran5-x32-cross");
+        catch!(PackageManager::from(Zypper), "sudo zypper in lib32gfortran5-x32-cross" => "lib32gfortran5-x32-cross");
+        catch!(PackageManager::from(Zypper), "sudo zypper install linux-perf-5.3" => "linux-perf-5.3");
+        catch!(PackageManager::from(Zypper), "sudo zypper in linux-perf-5.3" => "linux-perf-5.3");
+
+        // Multiple
+        catch!(PackageManager::from(Zypper), "sudo zypper install test test2" => "test", "test2");
+        catch!(PackageManager::from(Zypper), "sudo zypper in test test2" => "test", "test2");
+
+        // Ignore
+        catch!(PackageManager::from(Zypper), "sudo zypper test test2" => ());
+    }
+}


### PR DESCRIPTION
**What is the name of the package manager you would like to see support for?**

zypper

**What operating systems or derivative does this package manager support?**
- [ ] Windows
- [ ] Mac
- [x] Linux
- [ ] BSD
- [ ] Redox
- [ ] iOS
- [ ] Android
- [ ] Other, namely:

**If Linux, is it only for a specific distro?**
- [x] Yes, namely: opensuse
- [ ] No

**What type of package manager is this?**
- [ ] Programming language specific (e.g. Cargo for Rust)
- [x] General purpose (e.g. APT on Debian)
- [ ] Other, namely:

**Are administrator priviliges required? (sudo, etc.)**
- [x] Yes
- [ ] No

---

I took a stab at adding zypper support, but it's not fully working. Zypper supports a shortened version `in` in place of `install`, which is successfully captured for most of the test cases. Unfortunately, it's also matching and being removed from packages with `in` in them.

```
---- package_manager::zypper::tests::test_catch stdout ----
thread 'package_manager::zypper::tests::test_catch' panicked at 'assertion failed: `(left == right)`
  left: `"linux-perf-5.3"`,
 right: `"lux-perf-5.3"`: Package "lux-perf-5.3" should be matched, but it's not', src/package_manager/zypper.rs:64:9
```

Any ideas on a fix?
