### PR TITLE
Add paru

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
     | <img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/linux.svg" width="18" height="18" /> | GNU Guix |
     | <img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/nixos.svg" width="18" height="18" /><img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/linux.svg" width="18" height="18" /><img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/apple.svg" width="18" height="18" /> | Nix |
     | <img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/archlinux.svg" width="18" height="18" /> | Pacman |
+    | <img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/archlinux.svg" width="18" height="18" /> | Paru |
     | <img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/archlinux.svg" width="18" height="18" /> | RUA |
     | <img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/archlinux.svg" width="18" height="18" /> | Yay |
     | <img src="https://cdn.rawgit.com/simple-icons/simple-icons/develop/icons/suse.svg" width="18" height="18" /> | Zypper |
@@ -150,6 +151,8 @@ rustup component add rustfmt
 sudo apt install meld
 # -- or --
 pacman -S zsh
+# -- or --
+paru -S ventoy
 # -- or --
 rua install peek
 # -- or --

--- a/src/package_manager/mod.rs
+++ b/src/package_manager/mod.rs
@@ -13,6 +13,7 @@ mod guix;
 mod nix;
 mod npm;
 mod pacman;
+mod paru;
 mod pip;
 mod pip3;
 mod pkg;
@@ -35,6 +36,7 @@ pub use guix::Guix;
 pub use nix::Nix;
 pub use npm::Npm;
 pub use pacman::Pacman;
+pub use paru::Paru;
 pub use pip::Pip;
 pub use pip3::Pip3;
 pub use pkg::Pkg;
@@ -67,6 +69,7 @@ pub enum PackageManager {
     Nix,
     Npm,
     Pacman,
+    Paru,
     Pip,
     Pip3,
     Pkg,

--- a/src/package_manager/paru.rs
+++ b/src/package_manager/paru.rs
@@ -1,0 +1,125 @@
+use super::{CaptureFlag, PackageInstalledMethod, PackageManagerTrait};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Paru;
+
+impl PackageManagerTrait for Paru {
+    fn full_name(self) -> &'static str {
+        "Paru"
+    }
+
+    fn commands(self) -> Vec<&'static str> {
+        vec!["paru"]
+    }
+
+    fn sub_commands(self) -> Vec<&'static str> {
+        vec!["-S"]
+    }
+
+    fn install_command(self) -> &'static str {
+        "paru -S --noconfirm --quiet"
+    }
+
+    fn needs_root(self) -> bool {
+        true
+    }
+
+    fn is_installed(self, package: &str) -> PackageInstalledMethod {
+        PackageInstalledMethod::Script(format!("paru -Q {}", package))
+    }
+
+    fn known_flags_with_values(self) -> Vec<&'static str> {
+        vec![
+            // inherited from pacman
+            "-b",
+            "--dbpath",
+            "-r",
+            "--root",
+            "--arch",
+            "--cachedir",
+            "--color",
+            "--config",
+            "--gpgdir",
+            "--hookdir",
+            "--logfile",
+            "--sysroot",
+            "--assume-installed",
+            "--print-format",
+            "--ignore",
+            "--ignoregroup",
+            "--overwrite",
+            "-o",
+            "--owns",
+            "-s",
+            "--search",
+            "--asdeps",
+            "--asexplicit",
+            // new in paru
+            "--clonedir",
+            "--makepkg",
+            "--makepkgconf",
+            "--pacman",
+            "--pacman-conf",
+            "--git",
+            "--gitflags",
+            "--gpg",
+            "--gpgflags",
+            "--fm",
+            "--asp",
+            "--mflags",
+            "--bat",
+            "--batflags",
+            "--sudo",
+            "--sudoflags",
+            "--chrootflags",
+            "--completioninterval",
+            "--sortby",
+            "--searchby",
+            "--removemake",
+            "--limit",
+            "--redownload",
+            "--rebuild",
+            "--sudoloop",
+            "--localrepo",
+            "--chroot",
+            "--sign",
+            "--signdb",
+        ]
+    }
+
+    fn capture_flags(self) -> Vec<CaptureFlag> {
+        vec![]
+    }
+
+    fn invalidating_flags(self) -> Vec<&'static str> {
+        vec![]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Paru;
+    use crate::{catch, package_manager::PackageManager};
+
+    #[test]
+    fn test_package_manager() {
+        let manager = PackageManager::single_from_line("paru -S test").unwrap();
+        assert_eq!(manager, PackageManager::from(Paru));
+    }
+
+    #[test]
+    fn test_catch() {
+        // Regular invocation
+        catch!(PackageManager::from(Paru), "sudo paru -S test" => "test");
+        catch!(PackageManager::from(Paru), "paru -S test" => "test");
+        catch!(PackageManager::from(Paru), "sudo paru -S lib32gfortran5-x32-cross" => "lib32gfortran5-x32-cross");
+        catch!(PackageManager::from(Paru), "sudo paru -S linux-perf-5.3" => "linux-perf-5.3");
+
+        // Multiple
+        catch!(PackageManager::from(Paru), "sudo paru -S test test2" => "test", "test2");
+
+        // Ignore
+        catch!(PackageManager::from(Paru), "sudo paru test test2" => ());
+    }
+}


### PR DESCRIPTION
This PR adds support for another pacman wrapper, paru. The wrinkle here is that I often find myself using `paru <package>` to search and install interactively, which doesn't work with emplace. However, this PR covers the `paru -S <package>` use case, which I think is worthwhile on its own. An implementation for the former would require significant new functionality, which would probably be better suited for a new project entirely.

- **add paru**
- **include paru in README.md**
