### PR TITLE
chore: bump time crate to build with rust 1.80+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -790,9 +790,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ fn safe_main() -> Result<()> {
         }
         Some(("clean", _)) => clean::clean(config_path).context("cleaning packages"),
         Some(("history", sub_m)) => {
-            let hist_path: &PathBuf = sub_m
+            let hist_path: &Utf8PathBuf = sub_m
                 .get_one("history_file")
                 .context("path to history file is not provided")?;
 


### PR DESCRIPTION
seeing some build issue when building with rust 1.80+

relates to https://github.com/time-rs/time/issues/693